### PR TITLE
Only check changed classes for stability - #75

### DIFF
--- a/data-collection/src/main/java/refactoringml/App.java
+++ b/data-collection/src/main/java/refactoringml/App.java
@@ -170,7 +170,7 @@ public class App {
 					}
 
 					//collect the process metrics for the current commit
-					processMetrics.collectMetrics(currentCommit, superCommitMetaData, allRefactoringCommits, thereIsRefactoringToProcess);
+					processMetrics.collectMetrics(currentCommit, superCommitMetaData, allRefactoringCommits);
 
 					db.commit();
 				} catch (Exception e) {

--- a/data-collection/src/main/java/refactoringml/PMDatabase.java
+++ b/data-collection/src/main/java/refactoringml/PMDatabase.java
@@ -25,6 +25,8 @@ public class PMDatabase {
 	}
 
 	//Find all stable instances in the database
+	//Don't use these, because it is very inefficient
+	@Deprecated
 	public List<ProcessMetricTracker> findStableInstances() {
 		return database.values().stream()
 				.filter(pmTracker -> pmTracker.calculateStability(commitThresholds))
@@ -54,11 +56,15 @@ public class PMDatabase {
 	}
 
 	//Report a commit changing the given class file, the in memory database is updated accordingly
-	public void reportChanges(String fileName, CommitMetaData commitMetaData, String authorName, int linesAdded, int linesDeleted) {
+	//Returns the ProcessMetricsTracker if it is stable
+	public ProcessMetricTracker reportChanges(String fileName, CommitMetaData commitMetaData, String authorName, int linesAdded, int linesDeleted) {
 		ProcessMetricTracker pmTracker = database.getOrDefault(fileName, new ProcessMetricTracker(fileName, commitMetaData));
 		pmTracker.reportCommit(commitMetaData.getCommitId(), commitMetaData.getCommitMessage(), authorName, linesAdded, linesDeleted);
 
+		boolean isStable = pmTracker.calculateStability(commitThresholds);
 		database.put(fileName, pmTracker);
+
+		return isStable? pmTracker : null;
 	}
 
 	//Reset the tracker with latest refactoring and its commit meta data

--- a/data-collection/src/main/java/refactoringml/PMDatabase.java
+++ b/data-collection/src/main/java/refactoringml/PMDatabase.java
@@ -10,11 +10,8 @@ import java.util.stream.Collectors;
 public class PMDatabase {
 	//Map class files onto their original process metrics.
 	private Map<String, ProcessMetricTracker> database;
-	//All commit thresholds for this project for considering a class file as stable
-	private List<Integer> commitThresholds;
 
-	public PMDatabase (List<Integer> commitThresholds) {
-		this.commitThresholds = commitThresholds;
+	public PMDatabase () {
 		this.database = new HashMap<>();
 	}
 
@@ -27,7 +24,7 @@ public class PMDatabase {
 	//Find all stable instances in the database
 	//Don't use these, because it is very inefficient
 	@Deprecated
-	public List<ProcessMetricTracker> findStableInstances() {
+	public List<ProcessMetricTracker> findStableInstances(List<Integer> commitThresholds) {
 		return database.values().stream()
 				.filter(pmTracker -> pmTracker.calculateStability(commitThresholds))
 				.collect(Collectors.toList());
@@ -61,10 +58,8 @@ public class PMDatabase {
 		ProcessMetricTracker pmTracker = database.getOrDefault(fileName, new ProcessMetricTracker(fileName, commitMetaData));
 		pmTracker.reportCommit(commitMetaData.getCommitId(), commitMetaData.getCommitMessage(), authorName, linesAdded, linesDeleted);
 
-		boolean isStable = pmTracker.calculateStability(commitThresholds);
 		database.put(fileName, pmTracker);
-
-		return isStable? pmTracker : null;
+		return pmTracker;
 	}
 
 	//Reset the tracker with latest refactoring and its commit meta data
@@ -78,8 +73,6 @@ public class PMDatabase {
 
 	public String toString(){
 		return "PMDatabase{" +
-				"database=" + database.toString() + ",\n" +
-				"commitThreshold=" + commitThresholds.toString() +
-				"}";
+				"database=" + database.toString() + "}";
 	}
 }

--- a/data-collection/src/test/java/refactoringml/PMDatabaseTest.java
+++ b/data-collection/src/test/java/refactoringml/PMDatabaseTest.java
@@ -15,12 +15,10 @@ public class PMDatabaseTest {
     @Test
     public void constructor(){
         Map<String, ProcessMetricTracker> database = new HashMap<>();
-        PMDatabase pmDatabase = new PMDatabase(List.of(10, 25));
+        PMDatabase pmDatabase = new PMDatabase();
 
         String expected = "PMDatabase{" +
-                "database=" + database.toString() + ",\n" +
-                "commitThreshold=" + List.of(10, 25) +
-                "}";
+                "database=" + database.toString() + "}";
         Assert.assertEquals(expected, pmDatabase.toString());
     }
 
@@ -29,7 +27,7 @@ public class PMDatabaseTest {
     @Ignore
     @Test
     public void caseSensitivity(){
-        PMDatabase pmDatabase = new PMDatabase(List.of(10, 25));
+        PMDatabase pmDatabase = new PMDatabase();
 
         pmDatabase.reportChanges("a.Java", new CommitMetaData("#1", "n", "n", "0"), "R", 1, 1);
         pmDatabase.reportChanges("A.Java", new CommitMetaData("#1", "n", "n", "0"), "R", 1, 1);
@@ -41,11 +39,14 @@ public class PMDatabaseTest {
 
     @Test
     public void reportChanges(){
-        PMDatabase pmDatabase = new PMDatabase(List.of(10, 25));
+        PMDatabase pmDatabase = new PMDatabase();
+        Assert.assertEquals(0, pmDatabase.findStableInstances(List.of(10, 25)).size());
 
         //test if a new pm tracker is created with the right values
-        pmDatabase.reportChanges("a.Java", new CommitMetaData("#1", "null", "null", "0"), "Rafael", 10, 20);
+        ProcessMetricTracker aTracker = pmDatabase.reportChanges("a.Java", new CommitMetaData("#1", "null", "null", "0"), "Rafael", 10, 20);
         Assert.assertNotNull(pmDatabase.find("a.Java"));
+        Assert.assertEquals(aTracker, pmDatabase.find("a.Java"));
+        Assert.assertFalse(aTracker.calculateStability(List.of(10, 25)));
         Assert.assertEquals(1, pmDatabase.find("a.Java").getCommitCounter());
         Assert.assertNotNull(pmDatabase.find("a.Java").getBaseProcessMetrics());
         Assert.assertNotNull(pmDatabase.find("a.Java").getCurrentProcessMetrics());
@@ -69,7 +70,7 @@ public class PMDatabaseTest {
 
     @Test
     public void reportRefactoring(){
-        PMDatabase pmDatabase = new PMDatabase(List.of(10, 25));
+        PMDatabase pmDatabase = new PMDatabase();
 
         pmDatabase.reportRefactoring("a.Java", new CommitMetaData("#1", "null", "null", "0"));
         Assert.assertNotNull(pmDatabase.find("a.Java"));
@@ -103,14 +104,12 @@ public class PMDatabaseTest {
     //take care of case sensitivity
     @Test
     public void removeFile1(){
-        PMDatabase pmDatabase = new PMDatabase(List.of(10, 25));
+        PMDatabase pmDatabase = new PMDatabase();
         Map<String, ProcessMetricTracker> database = new HashMap<>();
 
         pmDatabase.removeFile("a.Java");
         String expected = "PMDatabase{" +
-                "database=" + database.toString() + ",\n" +
-                "commitThreshold=" + List.of(10, 25) +
-                "}";
+                "database=" + database.toString() + "}";
         Assert.assertEquals(expected, pmDatabase.toString());
 
         pmDatabase.reportChanges("a.Java", new CommitMetaData("#1", "null", "null", "0"), "Rafael", 10, 20);
@@ -124,7 +123,7 @@ public class PMDatabaseTest {
     //take care of case sensitivity
     @Test
     public void renameFile(){
-        PMDatabase pmDatabase = new PMDatabase(List.of(10, 25));
+        PMDatabase pmDatabase = new PMDatabase();
 
         ProcessMetricTracker oldPMTracker = pmDatabase.renameFile("a.Java", "A.Java",
                 new CommitMetaData("1", "null", "null", "0"));
@@ -164,7 +163,7 @@ public class PMDatabaseTest {
     //take care of case sensitivity
     @Test
     public void renameFile2(){
-        PMDatabase pmDatabase = new PMDatabase(List.of(10, 25));
+        PMDatabase pmDatabase = new PMDatabase();
         pmDatabase.reportChanges("a.Java", new CommitMetaData("#1", "null", "null", "0"), "Rafael", 10, 20);
         pmDatabase.renameFile("a.Java", "a.Java", new CommitMetaData("1", "null", "null", "0"));
 
@@ -178,7 +177,7 @@ public class PMDatabaseTest {
     //take care of renamed files
     @Test
     public void removeFile2(){
-        PMDatabase pmDatabase = new PMDatabase(List.of(10, 25));
+        PMDatabase pmDatabase = new PMDatabase();
         pmDatabase.reportChanges("a.Java", new CommitMetaData("#1", "null", "null", "0"), "Rafael", 10, 20);
         pmDatabase.renameFile("a.Java", "A.Java", new CommitMetaData("1", "null", "null", "0"));
 
@@ -190,92 +189,98 @@ public class PMDatabaseTest {
 
     @Test
     public void isStable1(){
-        PMDatabase pm = new PMDatabase(List.of(10, 25));
+        PMDatabase pm = new PMDatabase();
+        List<Integer> stableCommitCounts = List.of(10, 25);
 
         for(int i = 0; i < 9; i++) {
-            pm.reportChanges("a.Java", new CommitMetaData("#" + (i), "null", "null", "0"), "Rafael", 10, 20);
-            pm.reportChanges("b.Java", new CommitMetaData("#" + (i), "null", "null", "0"), "Rafael", 10, 20);
-            Assert.assertEquals(0, pm.findStableInstances().size());
+            ProcessMetricTracker aTracker = pm.reportChanges("a.Java", new CommitMetaData("#" + (i), "null", "null", "0"), "Rafael", 10, 20);
+            ProcessMetricTracker bTracker = pm.reportChanges("b.Java", new CommitMetaData("#" + (i), "null", "null", "0"), "Rafael", 10, 20);
+            Assert.assertFalse(aTracker.calculateStability(stableCommitCounts));
+            Assert.assertFalse(bTracker.calculateStability(stableCommitCounts));
             Assert.assertEquals(i + 1, pm.find("a.Java").getCommitCounter());
             Assert.assertEquals(i + 1, pm.find("b.Java").getCommitCounter());
         }
 
-        pm.reportChanges("b.Java", new CommitMetaData("#10", "null", "null", "0"), "Rafael", 10, 20);
+        ProcessMetricTracker bTracker = pm.reportChanges("b.Java", new CommitMetaData("#10", "null", "null", "0"), "Rafael", 10, 20);
+        Assert.assertEquals(pm.find("b.Java"), bTracker);
         Assert.assertEquals(10, pm.find("b.Java").getCommitCounter());
-        Assert.assertEquals(1, pm.findStableInstances().size());
+        Assert.assertTrue(bTracker.calculateStability(stableCommitCounts));
 
         for(int i = 0; i < 14; i++) {
             pm.reportChanges("b.Java", new CommitMetaData("#" + (i + 11), "null", "null", "0"), "Rafael", 10, 20);
-            Assert.assertEquals(0, pm.findStableInstances().size());
+            Assert.assertEquals(0, pm.findStableInstances(stableCommitCounts).size());
         }
 
         pm.reportChanges("a.Java", new CommitMetaData("#10", "null", "null", "0"), "Rafael", 10, 20);
-        Assert.assertEquals(1, pm.findStableInstances().size());
-        Assert.assertEquals(10, pm.findStableInstances().get(0).getCommitCountThreshold());
+        Assert.assertEquals(1, pm.findStableInstances(stableCommitCounts).size());
+        Assert.assertEquals(10, pm.findStableInstances(stableCommitCounts).get(0).getCommitCountThreshold());
 
         pm.reportChanges("b.Java", new CommitMetaData("#25", "null", "null", "0"), "Rafael", 10, 20);
-        Assert.assertEquals(2, pm.findStableInstances().size());
-        Assert.assertEquals(25, pm.findStableInstances().stream().filter(pmTracker -> pmTracker.getFileName().equals("b.Java")).collect(Collectors.toList()).get(0).getCommitCountThreshold());
+        Assert.assertEquals(2, pm.findStableInstances(stableCommitCounts).size());
+        Assert.assertEquals(25, pm.findStableInstances(stableCommitCounts).stream().filter(pmTracker -> pmTracker.getFileName().equals("b.Java")).collect(Collectors.toList()).get(0).getCommitCountThreshold());
 
         pm.reportRefactoring("b.Java", new CommitMetaData("#26", "null", "null", "0"));
-        Assert.assertEquals(1, pm.findStableInstances().size());
+        Assert.assertEquals(1, pm.findStableInstances(stableCommitCounts).size());
 
-        Assert.assertEquals(1, pm.findStableInstances().size());
-        Assert.assertEquals(10, pm.findStableInstances().get(0).getCommitCountThreshold());
+        Assert.assertEquals(1, pm.findStableInstances(stableCommitCounts).size());
+        Assert.assertEquals(10, pm.findStableInstances(stableCommitCounts).get(0).getCommitCountThreshold());
     }
 
     @Test
     public void isStable2(){
-        PMDatabase pm = new PMDatabase(List.of(10, 25));
+        PMDatabase pm = new PMDatabase();
+        List<Integer> stableCommitCounts = List.of(10, 25);
+
         for(int i = 0; i < 9; i++) {
             pm.reportChanges("a.Java", new CommitMetaData("#" + (i + 0), "null", "null", "0"), "Rafael", 10, 20);
             pm.reportChanges("b.Java", new CommitMetaData("#" + (i + 0), "null", "null", "0"), "Rafael", 10, 20);
-            Assert.assertEquals(0, pm.findStableInstances().size());
+            Assert.assertEquals(0, pm.findStableInstances(stableCommitCounts).size());
         }
 
         pm.reportRefactoring("a.Java", new CommitMetaData("#" + (10), "null", "null", "0"));
         Assert.assertEquals(0, pm.find("a.Java").getCommitCounter());
-        Assert.assertEquals(0, pm.findStableInstances().size());
+        Assert.assertEquals(0, pm.findStableInstances(stableCommitCounts).size());
 
         for(int i = 0; i < 2; i++) {
             pm.reportChanges("a.Java", new CommitMetaData("#" + (i + 10), "null", "null", "0"), "Rafael", 10, 20);
-            Assert.assertEquals(0, pm.findStableInstances().size());
+            Assert.assertEquals(0, pm.findStableInstances(stableCommitCounts).size());
             Assert.assertEquals(i + 1, pm.find("a.Java").getCommitCounter());
         }
 
         pm.reportChanges("b.Java", new CommitMetaData("#" + (9), "null", "null", "0"), "Rafael", 10, 20);
-        Assert.assertEquals(1, pm.findStableInstances().size());
+        Assert.assertEquals(1, pm.findStableInstances(stableCommitCounts).size());
 
         for(int i = 0; i < 7; i++) {
             pm.reportChanges("a.Java", new CommitMetaData("#" + (i + 12), "null", "null", "0"), "Rafael", 10, 20);
-            Assert.assertEquals(1, pm.findStableInstances().size());
+            Assert.assertEquals(1, pm.findStableInstances(stableCommitCounts).size());
         }
 
         pm.reportChanges("a.Java", new CommitMetaData("#" + (20), "null", "null", "0"), "Rafael", 10, 20);
-        Assert.assertEquals(2, pm.findStableInstances().size());
+        Assert.assertEquals(2, pm.findStableInstances(stableCommitCounts).size());
     }
 
     @Test
     public void multipleKs1(){
-        PMDatabase pm = new PMDatabase(List.of(10, 25));
+        PMDatabase pm = new PMDatabase();
+        List<Integer> stableCommitCounts = List.of(10, 25);
 
         for(int i = 0; i < 9; i++) {
             pm.reportChanges("a.Java", new CommitMetaData("#" + (i), "null", "null", "0"), "Rafael", 10, 20);
         }
         pm.reportChanges("a.Java", new CommitMetaData("#" + (10), "null", "null", "0"), "Rafael", 10, 20);
-        Assert.assertEquals(1, pm.findStableInstances().size());
-        Assert.assertEquals(10, pm.findStableInstances().get(0).getCommitCountThreshold());
+        Assert.assertEquals(1, pm.findStableInstances(stableCommitCounts).size());
+        Assert.assertEquals(10, pm.findStableInstances(stableCommitCounts).get(0).getCommitCountThreshold());
 
         pm.reportChanges("a.Java", new CommitMetaData("#" + (11), "null", "null", "0"), "Rafael", 10, 20);
-        Assert.assertEquals(0, pm.findStableInstances().size());
+        Assert.assertEquals(0, pm.findStableInstances(stableCommitCounts).size());
 
         for(int i = 0; i < 14; i++) {
             pm.reportChanges("a.Java", new CommitMetaData("#" + (i + 12), "null", "null", "0"), "Rafael", 10, 20);
         }
-        Assert.assertEquals(1, pm.findStableInstances().size());
-        Assert.assertEquals(25, pm.findStableInstances().get(0).getCommitCountThreshold());
+        Assert.assertEquals(1, pm.findStableInstances(stableCommitCounts).size());
+        Assert.assertEquals(25, pm.findStableInstances(stableCommitCounts).get(0).getCommitCountThreshold());
 
         pm.reportRefactoring("a.Java", new CommitMetaData("#" + (26), "null", "null", "0"));
-        Assert.assertEquals(0, pm.findStableInstances().size());
+        Assert.assertEquals(0, pm.findStableInstances(stableCommitCounts).size());
     }
 }

--- a/data-collection/src/test/java/refactoringml/ProcessMetricTrackerTest.java
+++ b/data-collection/src/test/java/refactoringml/ProcessMetricTrackerTest.java
@@ -160,7 +160,7 @@ public class ProcessMetricTrackerTest {
 
 	@Test
 	public void countQtyOfCommits(){
-		PMDatabase pmDatabase = new PMDatabase(List.of(10, 20));
+		PMDatabase pmDatabase = new PMDatabase();
 
 		for(int i = 0; i < 20; i++) {
 			pmDatabase.reportChanges("a.Java", new CommitMetaData("#" + i, "n", "n", "0"), "R", 1, 1);
@@ -172,11 +172,32 @@ public class ProcessMetricTrackerTest {
 		Assert.assertEquals(20, pmTracker.getCurrentProcessMetrics().linesDeleted);
 		Assert.assertEquals(20, pmTracker.getCurrentProcessMetrics().linesAdded);
 
-
-
 		pmTracker = pmDatabase.find("a.Java");
 		Assert.assertEquals(20, pmTracker.getCurrentProcessMetrics().qtyOfCommits);
 		Assert.assertEquals(20, pmTracker.getCurrentProcessMetrics().linesDeleted);
 		Assert.assertEquals(20, pmTracker.getCurrentProcessMetrics().linesAdded);
+	}
+
+	@Test
+	public void calculateStability(){
+		ProcessMetricTracker pm = new ProcessMetricTracker("a.Java", new CommitMetaData());
+		List<Integer> stableCommitCounts = List.of(10, 25);
+
+		for(int i = 0; i < 9; i++) {
+			pm.reportCommit("#" + i,"commit #" + i,"Mauricio", 1, 1);
+			Assert.assertFalse(pm.calculateStability(stableCommitCounts));
+			Assert.assertFalse(pm.calculateStability(stableCommitCounts));
+		}
+		pm.reportCommit("#10","commit #10","Mauricio", 1, 1);
+		Assert.assertTrue(pm.calculateStability(stableCommitCounts));
+		Assert.assertTrue(pm.calculateStability(stableCommitCounts));
+
+		for(int i = 0; i < 14; i++) {
+			pm.reportCommit("#" + (i + 10),"commit #" + (i + 10),"Mauricio", 1, 1);
+			Assert.assertFalse(pm.calculateStability(stableCommitCounts));
+		}
+
+		pm.reportCommit("#25","commit #25","Mauricio", 1, 1);
+		Assert.assertTrue(pm.calculateStability(stableCommitCounts));
 	}
 }


### PR DESCRIPTION
 * Check class stability only after a commit was reported for this class
 * Adopt Tests and remove unused code from PMTracker