### PR TITLE
Fix StableCommit Duplicates in the DB - #63

### DIFF
--- a/data-collection/src/test/java/integration/realprojects/ApacheCommonsCSVIntegrationTest.java
+++ b/data-collection/src/test/java/integration/realprojects/ApacheCommonsCSVIntegrationTest.java
@@ -102,25 +102,30 @@ public class ApacheCommonsCSVIntegrationTest extends IntegrationBaseTest {
     @Test
     public void stable_CSVFormat() {
         String fileName = "src/main/java/org/apache/commons/csv/CSVFormat.java";
-        List<StableCommit> stableCommitList = getStableCommits().stream().filter(commit ->
+        List<StableCommit> stableCommitListLevel2 = getStableCommits().stream().filter(commit ->
                 commit.getFilePath().equals(fileName) && commit.getLevel() == 2).collect(Collectors.toList());
 
-        Assert.assertEquals(43, stableCommitList.size());
+        Assert.assertEquals(17, stableCommitListLevel2.size());
 
-        assertStableCommit(stableCommitList, "67d150adc88b806e52470d110a438d9107e72ed5");
+        List<StableCommit> stableCommitListLevel3 = getStableCommits().stream().filter(commit ->
+                commit.getFilePath().equals(fileName) && commit.getLevel() == 3).collect(Collectors.toList());
+
+        Assert.assertEquals(43, stableCommitListLevel3.size());
+
+        assertStableCommit(stableCommitListLevel2, "67d150adc88b806e52470d110a438d9107e72ed5");
 
         // also manually validated
-        Assert.assertEquals(5, stableCommitList.get(0).getClassMetrics().getClassNumberOfPublicFields());
-        Assert.assertEquals(39, stableCommitList.get(0).getClassMetrics().getClassNumberOfPublicMethods());
-        Assert.assertEquals(13, stableCommitList.get(0).getClassMetrics().getClassNumberOfPrivateFields());
-        Assert.assertEquals(4, stableCommitList.get(0).getClassMetrics().getClassNumberOfPrivateMethods());
+        Assert.assertEquals(5, stableCommitListLevel2.get(0).getClassMetrics().getClassNumberOfPublicFields());
+        Assert.assertEquals(39, stableCommitListLevel2.get(0).getClassMetrics().getClassNumberOfPublicMethods());
+        Assert.assertEquals(13, stableCommitListLevel2.get(0).getClassMetrics().getClassNumberOfPrivateFields());
+        Assert.assertEquals(4, stableCommitListLevel2.get(0).getClassMetrics().getClassNumberOfPrivateMethods());
 
         // also manually validated
-        Assert.assertEquals(215, stableCommitList.get(0).getProcessMetrics().qtyOfCommits);
+        Assert.assertEquals(215, stableCommitListLevel2.get(0).getProcessMetrics().qtyOfCommits);
 
         // in refactorings_CSVFormat, we see that there are 82 refactorings in total.
         // after this commit, there was just one more refactoring. Thus, 81 refactorings
-        Assert.assertEquals(194, stableCommitList.get(0).getProcessMetrics().refactoringsInvolved);
+        Assert.assertEquals(194, stableCommitListLevel2.get(0).getProcessMetrics().refactoringsInvolved);
     }
 
     @Test

--- a/data-collection/src/test/java/integration/realprojects/ApacheCommonsCliIntegrationTest.java
+++ b/data-collection/src/test/java/integration/realprojects/ApacheCommonsCliIntegrationTest.java
@@ -49,12 +49,32 @@ public class ApacheCommonsCliIntegrationTest extends IntegrationBaseTest {
 	public void isInnerClassStable(){
 		List<StableCommit> areInnerClassesInStable = getStableCommits().stream().filter(commit ->
 				commit.getClassMetrics().isInnerClass()).collect(Collectors.toList());
+		Assert.assertEquals(43, areInnerClassesInStable.size());
+
 		List<StableCommit> areNotInnerClassesInStable = getStableCommits().stream().filter(commit ->
 				!commit.getClassMetrics().isInnerClass()).collect(Collectors.toList());
+		Assert.assertEquals(1460, areNotInnerClassesInStable.size());
 
-		Assert.assertEquals(65, areInnerClassesInStable.size());
-		Assert.assertEquals(2219, areNotInnerClassesInStable.size());
-		Assert.assertEquals(2284, getStableCommits().size());
+		Assert.assertEquals(1503, getStableCommits().size());
+	}
+
+	@Test
+	public void isInnerClassStable2(){
+		List<StableCommit> areInnerClassesInStableLevel2 = getStableCommits().stream().filter(commit ->
+				commit.getClassMetrics().isInnerClass() && commit.getLevel() == 2).collect(Collectors.toList());
+		Assert.assertEquals(6, areInnerClassesInStableLevel2.size());
+
+		List<StableCommit> areInnerClassesInStableLevel3 = getStableCommits().stream().filter(commit ->
+				commit.getClassMetrics().isInnerClass() && commit.getLevel() == 3).collect(Collectors.toList());
+		Assert.assertEquals(27, areInnerClassesInStableLevel3.size());
+
+		List<StableCommit> areNotInnerClassesInStableLevel2 = getStableCommits().stream().filter(commit ->
+				!commit.getClassMetrics().isInnerClass() && commit.getLevel() == 2).collect(Collectors.toList());
+		Assert.assertEquals(169, areNotInnerClassesInStableLevel2.size());
+
+		List<StableCommit> areNotInnerClassesInStableLevel3 = getStableCommits().stream().filter(commit ->
+				!commit.getClassMetrics().isInnerClass() && commit.getLevel() == 3).collect(Collectors.toList());
+		Assert.assertEquals(1381, areNotInnerClassesInStableLevel3.size());
 	}
 
 	@Test
@@ -84,7 +104,7 @@ public class ApacheCommonsCliIntegrationTest extends IntegrationBaseTest {
 				getStableCommits(),
 				"38ab386d9d86c6cacea817954064bb25fba312aa",
 				"org.apache.commons.cli.Option.Builder",
-				35);
+				24);
 	}
 
 	@Test
@@ -98,17 +118,17 @@ public class ApacheCommonsCliIntegrationTest extends IntegrationBaseTest {
 				getStableCommits(),
 				"8f95e4a724350f9f80429c2af1c3ac9bb2b2c2db",
 				"org.apache.commons.cli.HelpFormatter.OptionComparator",
-				6);
+				4);
 		assertInnerClass(
 				getStableCommits(),
 				"51f4ee70a4f5a8a921557b2a53413fb19c52b918",
 				"org.apache.commons.cli.HelpFormatter.OptionComparator",
-				6);
+				4);
 		assertInnerClass(
 				getStableCommits(),
 				"3936da9d3fe37bcd20dd37216d82608e5917be07",
 				"org.apache.commons.cli.HelpFormatter.OptionComparator",
-				4);
+				2);
 	}
 
 	@Test
@@ -117,12 +137,12 @@ public class ApacheCommonsCliIntegrationTest extends IntegrationBaseTest {
 				getStableCommits(),
 				"cd745ecf52fb2fe8fed1c67fc9149e4be11a73f0",
 				"org.apache.commons.cli.OptionTest.TestOption",
-				7);
+				4);
 		assertInnerClass(
 				getStableCommits(),
 				"cd745ecf52fb2fe8fed1c67fc9149e4be11a73f0",
 				"org.apache.commons.cli.OptionTest.DefaultOption",
-				7);
+				5);
 	}
 
 	@Test

--- a/data-collection/src/test/java/integration/realprojects/ApacheCommonsCliIntegrationTest.java
+++ b/data-collection/src/test/java/integration/realprojects/ApacheCommonsCliIntegrationTest.java
@@ -53,9 +53,9 @@ public class ApacheCommonsCliIntegrationTest extends IntegrationBaseTest {
 
 		List<StableCommit> areNotInnerClassesInStable = getStableCommits().stream().filter(commit ->
 				!commit.getClassMetrics().isInnerClass()).collect(Collectors.toList());
-		Assert.assertEquals(1460, areNotInnerClassesInStable.size());
+		Assert.assertEquals(1726, areNotInnerClassesInStable.size());
 
-		Assert.assertEquals(1503, getStableCommits().size());
+		Assert.assertEquals(1769, getStableCommits().size());
 	}
 
 	@Test

--- a/data-collection/src/test/java/integration/toyprojects/R3ToyProjectTest.java
+++ b/data-collection/src/test/java/integration/toyprojects/R3ToyProjectTest.java
@@ -100,17 +100,17 @@ public class R3ToyProjectTest extends IntegrationBaseTest {
 		//Manually Verified
 		List<StableCommit> stableCommitLow = getStableCommits().stream().filter(commit ->
 				commit.getCommitThreshold() == 3).collect(Collectors.toList());
-		Assert.assertEquals(9, stableCommitLow.size());
+		Assert.assertEquals(3, stableCommitLow.size());
 
 		List<StableCommit> stableCommitsMedium = getStableCommits().stream().filter(commit ->
 				commit.getCommitThreshold() == 5).collect(Collectors.toList());
-		Assert.assertEquals(3, stableCommitsMedium.size());
+		Assert.assertEquals(1, stableCommitsMedium.size());
 
 		List<StableCommit> stableCommitsHigh = getStableCommits().stream().filter(commit ->
 				commit.getCommitThreshold() == 6).collect(Collectors.toList());
-		Assert.assertEquals(3, stableCommitsHigh.size());
+		Assert.assertEquals(1, stableCommitsHigh.size());
 
-		Assert.assertEquals(15, getStableCommits().size());
+		Assert.assertEquals(5, getStableCommits().size());
 
 		String lastRefactoring = "061febd820977f2b00c4926634f09908cc5b8b08";
 		List<StableCommit> filteredList = (List<StableCommit>) filterCommit(getStableCommits(), lastRefactoring);


### PR DESCRIPTION
 * Only store StableCommits with as complete as possible in the DB
 * Filter duplicates from function codeMetrics in PMCollector
 * Manually validated stable tests