### PR TITLE
Fix bug when looking for methods with more than a single generic type

### DIFF
--- a/data-collection/src/main/java/refactoringml/App.java
+++ b/data-collection/src/main/java/refactoringml/App.java
@@ -161,7 +161,6 @@ public class App {
 					//check if refactoring miner detected a refactoring we study
 					if (thereIsRefactoringToProcess && !refactoringsToProcess.isEmpty()) {
 						db.persist(superCommitMetaData);
-						superCommitMetaData = db.loadCommitMetaData(superCommitMetaData.getId());
 						allRefactoringCommits = refactoringAnalyzer.collectCommitData(currentCommit, superCommitMetaData, refactoringsToProcess);
 					} else if (currentCommit.getParentCount() == 1 && thereIsRefactoringToProcess) {
 						// timeout happened, so count it as an exception

--- a/data-collection/src/main/java/refactoringml/RefactoringAnalyzer.java
+++ b/data-collection/src/main/java/refactoringml/RefactoringAnalyzer.java
@@ -192,7 +192,7 @@ public class RefactoringAnalyzer {
 					// for some reason we did not find the method, let's remove it from the list.
 					String methods = ck.getMethods().stream().map(x -> CKUtils.simplifyFullName(x.getMethodName())).reduce("", (a, b) -> a + ", " + b);
 					log.error("CK did not find the refactored method: " + fullRefactoredMethod + " for the refactoring type: " + refactoring.getName() + " on commit " + commitMetaData.getCommitId() +
-							"on class " + refactoredClass +
+							"on class " + refactoredClass + " on commit " + commitMetaData.getCommitId() +
 							"\nAll methods found by CK: " + methods);
 					return;
 				} else {

--- a/data-collection/src/main/java/refactoringml/util/CKUtils.java
+++ b/data-collection/src/main/java/refactoringml/util/CKUtils.java
@@ -23,6 +23,7 @@ public class CKUtils {
 		String rightPart = fullName.substring(fullName.indexOf("[") + 1, fullName.length()-1);
 
 		rightPart = cleanGenerics(rightPart);
+		System.out.println(rightPart);
 
 		String[] parameters = rightPart.split(",");
 		String cleanParams = Arrays.stream(parameters).map(p -> {
@@ -45,7 +46,7 @@ public class CKUtils {
 	// Why? Because the way JDT resolves (and stringuifies) class names in TypeDeclarations
 	// is different from the way it resolves (and stringuifies) in MethodBinding...
 	private static String cleanGenerics(String clazzName) {
-		return clazzName.replaceAll("\\$", "\\.").replaceAll("<.*>", "").trim();
+		return clazzName.replaceAll("\\$", "\\.").replaceAll("<.*?>", "").trim();
 	}
 
 	public static String cleanClassName(String clazzName) {

--- a/data-collection/src/test/java/refactoringml/CKUtilsTest.java
+++ b/data-collection/src/test/java/refactoringml/CKUtilsTest.java
@@ -37,4 +37,13 @@ public class CKUtilsTest {
 		String simplified = CKUtils.simplifyFullName("CSVRecord/5[java.lang.String[],java.util.Map<java.lang.String,java.lang.Integer>,java.lang.String,long,long]");
 		Assert.assertEquals("CSVRecord/5[String[],Map,String,long,long]", simplified);
 	}
+
+	@Test
+	public void fullClassNamesAndGenerics() {
+		String fullVersion = "doConnect/3[com.ning.http.client.providers.Request,com.ning.http.client.providers.AsyncHandler<T>,com.ning.http.client.providers.NettyResponseFuture<T>]";
+
+		String simplified = CKUtils.simplifyFullName(fullVersion);
+
+		Assert.assertEquals("doConnect/3[Request,AsyncHandler,NettyResponseFuture]", simplified);
+	}
 }


### PR DESCRIPTION
Our regex was greedy, so whenever a method had two generic parameters (e.g., `method/2[A<X>, B<X>]`, the regex was basically getting everything from the first < to the last >. 