### PR TITLE
Improve how we store the source code files

### DIFF
--- a/data-collection/src/main/java/refactoringml/RefactoringAnalyzer.java
+++ b/data-collection/src/main/java/refactoringml/RefactoringAnalyzer.java
@@ -53,11 +53,8 @@ public class RefactoringAnalyzer {
 	public List<RefactoringCommit> collectCommitData(RevCommit commit, CommitMetaData superCommitMetaData, List<Refactoring> refactoringsToProcess) throws IOException {
 		List<RefactoringCommit> allRefactorings = new ArrayList<>();
 
-		try (DiffFormatter diffFormatter = new DiffFormatter(DisabledOutputStream.INSTANCE)) {
-			diffFormatter.setRepository(repository);
-			diffFormatter.setDetectRenames(true);
+		try {
 			RevCommit commitParent = commit.getParent(0);
-			List<DiffEntry> entries = diffFormatter.scan(commitParent, commit);
 
 			//Iterate over all Refactorings found for this commit
 			for (Refactoring refactoring : refactoringsToProcess) {
@@ -69,55 +66,22 @@ public class RefactoringAnalyzer {
 					String refactoredClassFile = pair.getLeft();
 					String refactoredClassName = pair.getRight();
 
-					//filter the diff entries for class files affected by this refactoring
-					Optional<DiffEntry> refactoredEntry = entries.stream()
-							.filter(entry -> {
-								String oldFile = enforceUnixPaths(entry.getOldPath());
-								String newFile = enforceUnixPaths(entry.getNewPath());
-								return refactoredClassFile.equals(oldFile) ||
-										refactoredClassFile.equals(newFile);
-							})
-							.findFirst();
-
-					// this should not happen...
-					if (refactoredEntry.isEmpty()) {
-						log.error("Old classes in DiffEntry: " + entries.stream().map(x -> enforceUnixPaths(x.getOldPath())).collect(Collectors.toList()) + " but " + refactoredClassFile + " is not there.");
-						log.error("New classes in DiffEntry: " + entries.stream().map(x -> enforceUnixPaths(x.getNewPath())).collect(Collectors.toList()) + " but " + refactoredClassFile + " is not there.");
-						throw new RuntimeException("RefactoringMiner finds a refactoring for class '" + refactoredClassName + "', but we can't find it in DiffEntry: '" + refactoring.getRefactoringType() + "'. Check RefactoringAnalyzer.java for reasons why this can happen.");
-					}
-
-					// we found the file, let's get its metrics!
-					DiffEntry entry = refactoredEntry.get();
-					diffFormatter.toFileHeader(entry);
-
-					String oldFileName = enforceUnixPaths(entry.getOldPath());
-					String currentFileName = enforceUnixPaths(entry.getNewPath());
-
-					if(nonClassFile(oldFileName)){
-						log.error("Refactoring miner found a refactoring for a newly introduced class file on commit: " + commit.getName() + " for new class file: " + currentFileName);
-						continue;
-					}
-
-					// Now, we get the contents of the file before
-					String sourceCodeBefore = readFileFromGit(repository, commitParent, oldFileName);
-					// save the old version of the file in a temp dir to execute the CK tool
-					// Note: in older versions of the tool, we used to use the 'new name' for the file name. It does not make a lot of difference,
-					// but later we notice it might do in cases of file renames and refactorings in the same commit.
-					tempDir = createTmpDir();
-					writeFile(tempDir + "/" + oldFileName, sourceCodeBefore);
-
-					RefactoringCommit refactoringCommit = calculateCkMetrics(refactoredClassName, superCommitMetaData, refactoring, refactoringSummary);
-					cleanTempDir(tempDir);
+					// build the full RefactoringCommit object
+					RefactoringCommit refactoringCommit = buildRefactoringCommitObject(superCommitMetaData, commitParent, refactoring, refactoringSummary, refactoredClassName, refactoredClassFile);
 
 					if (refactoringCommit != null) {
 						// mark it for the process metrics collection
 						allRefactorings.add(refactoringCommit);
-						storeSourceCode(commit, oldFileName, currentFileName, sourceCodeBefore, refactoringCommit);
+
+						if(storeFullSourceCode)
+							storeSourceCode(refactoringCommit.getId(), refactoring, commitParent, commit);
 					} else {
 						log.debug("RefactoringCommit instance was not created for the class: " + refactoredClassName + " and the refactoring type: " + refactoring.getName()  + " on commit " + commit.getName());
 					}
 				}
+
 			}
+
 		} catch (Exception e){
 			log.error("Failed to collect commit data for refactored commit: "+ superCommitMetaData.getCommitId(), e);
 		}
@@ -125,26 +89,33 @@ public class RefactoringAnalyzer {
 		return allRefactorings;
     }
 
-	protected void storeSourceCode(RevCommit commit, String oldFileName, String currentFileName, String sourceCodeBefore, RefactoringCommit refactoringCommit) throws IOException {
-		if (storeFullSourceCode) {
-			// let's get the source code of the file after the refactoring
-			// but only if not deleted
-			String sourceCodeAfter = !nonClassFile(currentFileName) ? readFileFromGit(repository, commit, oldFileName) : "";
+	protected RefactoringCommit buildRefactoringCommitObject(CommitMetaData superCommitMetaData, RevCommit commitParent, Refactoring refactoring, String refactoringSummary, String refactoredClassName, String oldFileName) throws IOException {
+		// Now, we get the contents of the file before
+		String sourceCodeBefore = readFileFromGit(repository, commitParent, oldFileName);
+		tempDir = createTmpDir();
+		writeFile(tempDir + "/" + oldFileName, sourceCodeBefore);
 
-			// store the before and after versions for the deep learning training
-			// note that we save the file before with the same name of the current file name,
-			// as to help in finding it (from the SQL query to the file)
-			saveSourceCode(oldFileName, sourceCodeBefore, currentFileName, sourceCodeAfter, refactoringCommit);
-		}
+		RefactoringCommit refactoringCommit = calculateCkMetrics(refactoredClassName, superCommitMetaData, refactoring, refactoringSummary);
+		cleanTempDir(tempDir);
+		return refactoringCommit;
 	}
 
-	private void saveSourceCode(String fileNameBefore, String sourceCodeBefore, String fileNameAfter, String sourceCodeAfter, RefactoringCommit refactoringCommit) throws FileNotFoundException {
-		String onlyFileNameBefore = fileNameOnly(fileNameBefore);
-		writeFile(fileStorageDir + refactoringCommit.getId() + "/before-refactoring/" + onlyFileNameBefore, sourceCodeBefore);
+	private void storeSourceCode(long id, Refactoring refactoring, RevCommit commitParent, RevCommit currentCommit) throws IOException {
 
-		if(!sourceCodeAfter.isEmpty()) {
-			String onlyFileNameAfter = fileNameOnly(fileNameAfter);
-			writeFile(fileStorageDir + refactoringCommit.getId() + "/after-refactoring/" + onlyFileNameAfter, sourceCodeAfter);
+		// for the before refactoring, we get its source code in the previous commit
+		for (ImmutablePair<String, String> pair : refactoring.getInvolvedClassesBeforeRefactoring()) {
+			String fileName = pair.getLeft();
+
+			String sourceCode = readFileFromGit(repository, commitParent, fileName);
+			writeFile(fileStorageDir + id + "/before/" + fileNameOnly(fileName), sourceCode);
+		}
+
+		// for the after refactoring, we get its source code in the current commit
+		for (ImmutablePair<String, String> pair : refactoring.getInvolvedClassesAfterRefactoring()) {
+			String fileName = pair.getLeft();
+
+			String sourceCode = readFileFromGit(repository, currentCommit, fileName);
+			writeFile(fileStorageDir + id + "/after/" + fileNameOnly(fileName), sourceCode);
 		}
 	}
 

--- a/data-collection/src/main/java/refactoringml/RefactoringAnalyzer.java
+++ b/data-collection/src/main/java/refactoringml/RefactoringAnalyzer.java
@@ -4,25 +4,17 @@ import com.github.mauricioaniche.ck.CKMethodResult;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.eclipse.jgit.diff.DiffEntry;
-import org.eclipse.jgit.diff.DiffFormatter;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.util.io.DisabledOutputStream;
 import org.refactoringminer.api.Refactoring;
 import refactoringml.db.*;
 import refactoringml.util.CKUtils;
-import refactoringml.util.FilePathUtils;
-import refactoringml.util.FileUtils;
 import refactoringml.util.RefactoringUtils;
 
-import javax.persistence.PersistenceException;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static refactoringml.util.CKUtils.*;
 import static refactoringml.util.FilePathUtils.*;
@@ -106,16 +98,24 @@ public class RefactoringAnalyzer {
 		for (ImmutablePair<String, String> pair : refactoring.getInvolvedClassesBeforeRefactoring()) {
 			String fileName = pair.getLeft();
 
-			String sourceCode = readFileFromGit(repository, commitParent, fileName);
-			writeFile(fileStorageDir + id + "/before/" + fileNameOnly(fileName), sourceCode);
+			try {
+				String sourceCode = readFileFromGit(repository, commitParent, fileName);
+				writeFile(fileStorageDir + id + "/before/" + fileNameOnly(fileName), sourceCode);
+			} catch(Exception e) {
+				log.error("Could not write raw source code for file before refactoring, id=" + id + ", file name=" + fileName + ", commit=" + commitParent.getId().getName(), e);
+			}
 		}
 
 		// for the after refactoring, we get its source code in the current commit
 		for (ImmutablePair<String, String> pair : refactoring.getInvolvedClassesAfterRefactoring()) {
 			String fileName = pair.getLeft();
 
-			String sourceCode = readFileFromGit(repository, currentCommit, fileName);
-			writeFile(fileStorageDir + id + "/after/" + fileNameOnly(fileName), sourceCode);
+			try {
+				String sourceCode = readFileFromGit(repository, currentCommit, fileName);
+				writeFile(fileStorageDir + id + "/after/" + fileNameOnly(fileName), sourceCode);
+			} catch(Exception e) {
+				log.error("Could not write raw source code for file after refactoring, id=" + id + ", file name=" + fileName + ", commit=" + currentCommit.getId().getName(), e);
+			}
 		}
 	}
 

--- a/data-collection/src/main/java/refactoringml/RefactoringAnalyzer.java
+++ b/data-collection/src/main/java/refactoringml/RefactoringAnalyzer.java
@@ -112,17 +112,7 @@ public class RefactoringAnalyzer {
 					if (refactoringCommit != null) {
 						// mark it for the process metrics collection
 						allRefactorings.add(refactoringCommit);
-
-						if (storeFullSourceCode) {
-							// let's get the source code of the file after the refactoring
-							// but only if not deleted
-							String sourceCodeAfter = !nonClassFile(currentFileName) ? readFileFromGit(repository, commit, oldFileName) : "";
-
-							// store the before and after versions for the deep learning training
-							// note that we save the file before with the same name of the current file name,
-							// as to help in finding it (from the SQL query to the file)
-							saveSourceCode(oldFileName, sourceCodeBefore, currentFileName, sourceCodeAfter, refactoringCommit);
-						}
+						storeSourceCode(commit, oldFileName, currentFileName, sourceCodeBefore, refactoringCommit);
 					} else {
 						log.debug("RefactoringCommit instance was not created for the class: " + refactoredClassName + " and the refactoring type: " + refactoring.getName()  + " on commit " + commit.getName());
 					}
@@ -134,6 +124,19 @@ public class RefactoringAnalyzer {
 
 		return allRefactorings;
     }
+
+	protected void storeSourceCode(RevCommit commit, String oldFileName, String currentFileName, String sourceCodeBefore, RefactoringCommit refactoringCommit) throws IOException {
+		if (storeFullSourceCode) {
+			// let's get the source code of the file after the refactoring
+			// but only if not deleted
+			String sourceCodeAfter = !nonClassFile(currentFileName) ? readFileFromGit(repository, commit, oldFileName) : "";
+
+			// store the before and after versions for the deep learning training
+			// note that we save the file before with the same name of the current file name,
+			// as to help in finding it (from the SQL query to the file)
+			saveSourceCode(oldFileName, sourceCodeBefore, currentFileName, sourceCodeAfter, refactoringCommit);
+		}
+	}
 
 	private void saveSourceCode(String fileNameBefore, String sourceCodeBefore, String fileNameAfter, String sourceCodeAfter, RefactoringCommit refactoringCommit) throws FileNotFoundException {
 		String onlyFileNameBefore = fileNameOnly(fileNameBefore);

--- a/data-collection/src/main/java/refactoringml/util/FilePathUtils.java
+++ b/data-collection/src/main/java/refactoringml/util/FilePathUtils.java
@@ -5,7 +5,6 @@ import org.apache.logging.log4j.Logger;
 import java.io.File;
 
 public class FilePathUtils {
-	private static final Logger log = LogManager.getLogger(FilePathUtils.class);
 
 	public static String classFromFileName (String fileName) {
 		String[] splittedFile = enforceUnixPaths(fileName).replace("\\", "/").split("/");

--- a/data-collection/src/main/java/refactoringml/util/FilePathUtils.java
+++ b/data-collection/src/main/java/refactoringml/util/FilePathUtils.java
@@ -22,11 +22,7 @@ public class FilePathUtils {
 	}
 
 	public static String fileNameOnly (String fileName) {
-		return new File(enforceUnixPaths(fileName)).getName();
-	}
-
-	public static boolean createAllDirs (String base, String fileName) {
-		return new File(lastSlashDir(base) + dirsOnly(fileName)).mkdirs();
+		return new File(fileName).getName();
 	}
 
 	/*

--- a/data-collection/src/main/java/refactoringml/util/FileUtils.java
+++ b/data-collection/src/main/java/refactoringml/util/FileUtils.java
@@ -12,23 +12,6 @@ import static refactoringml.util.FilePathUtils.*;
 
 public class FileUtils {
 
-	public static String[] getAllDirs(String path) {
-		return getAllDirs(path, null);
-	}
-
-	public static String[] getAllDirs(String path, String regex) {
-		try {
-			return Files.walk(Paths.get(path))
-					.filter(Files::isDirectory)
-					.filter(x -> !x.toAbsolutePath().toString().contains(".git"))
-					.filter(x -> (regex!=null?x.toAbsolutePath().toString().contains(regex):true))
-					.map(x -> x.toAbsolutePath().toString())
-					.toArray(String[]::new);
-		} catch(Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
 	public static String[] getAllJavaFiles(String path) {
 		return getAllJavaFiles(path, null);
 	}

--- a/data-collection/src/main/java/refactoringml/util/FileUtils.java
+++ b/data-collection/src/main/java/refactoringml/util/FileUtils.java
@@ -102,4 +102,5 @@ public class FileUtils {
 	public static  boolean nonClassFile(String fileName) {
 		return fileName.equals("/dev/null");
 	}
+
 }

--- a/data-collection/src/main/java/refactoringml/util/RefactoringUtils.java
+++ b/data-collection/src/main/java/refactoringml/util/RefactoringUtils.java
@@ -354,18 +354,4 @@ public class RefactoringUtils {
 		return Sets.newHashSet(it.next());
 	}
 
-	public static String getMethodAndOrVariableNameIfAny(RefactoringCommit refactoringCommit) {
-		if(refactoringCommit.getLevel() == Level.METHOD.ordinal()) {
-			return refactoringCommit.getMethodMetrics().getShortMethodName();
-		}
-		if(refactoringCommit.getLevel() == Level.VARIABLE.ordinal()) {
-			return refactoringCommit.getMethodMetrics().getShortMethodName() + "-" + refactoringCommit.getVariableMetrics().getVariableName();
-		}
-		if(refactoringCommit.getLevel() == Level.ATTRIBUTE.ordinal()) {
-			return refactoringCommit.getFieldMetrics().getFieldName();
-		}
-
-		// this is no method, variable, or attribute refactoring
-		return "";
-	}
 }

--- a/data-collection/src/test/java/integration/IntegrationBaseTest.java
+++ b/data-collection/src/test/java/integration/IntegrationBaseTest.java
@@ -37,6 +37,10 @@ public abstract class IntegrationBaseTest {
 		return true;
 	}
 
+	protected boolean storeSourceCode() {
+		return false;
+	}
+
 	protected String getLastCommit() {
 		return null;
 	}
@@ -71,7 +75,7 @@ public abstract class IntegrationBaseTest {
 				outputDir,
 				db,
 				getLastCommit(),
-				false);
+				storeSourceCode());
 
 		project = app.run();
 	}

--- a/data-collection/src/test/java/integration/toyprojects/R6ToyProjectTest.java
+++ b/data-collection/src/test/java/integration/toyprojects/R6ToyProjectTest.java
@@ -12,7 +12,11 @@ import refactoringml.util.JGitUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -100,10 +104,9 @@ public class R6ToyProjectTest extends IntegrationBaseTest {
 	}
 
 	@Test
-	void assertStoreSourceCode() throws IOException {
+	void assertStoreSourceCode() {
 
 		String[] allJavaFiles = FileUtils.getAllJavaFiles(outputDir);
-		Arrays.stream(allJavaFiles).forEach(x -> System.out.println(x));
 		Assertions.assertEquals(14, allJavaFiles.length);
 
 		List<RefactoringCommit> rcs = getRefactoringCommits();
@@ -115,10 +118,67 @@ public class R6ToyProjectTest extends IntegrationBaseTest {
 			Assertions.assertTrue(found);
 		}
 
-		// TODO: assert the content of the file
-		// Repository repo = getRepository();
-		// JGitUtils.readFileFromGit(repo, "4125d9a212381d132e47c1d53b8dbb0b0a7eb7f3", )
+		long smallestId = rcs.stream().min(Comparator.comparingLong(x -> x.getId())).get().getId();
 
+		// r1: rename variable
+		String r1Before = Arrays.stream(allJavaFiles).filter(x -> x.contains("/" + smallestId + "/before/A.java")).findFirst().get();
+		String r1After = Arrays.stream(allJavaFiles).filter(x -> x.contains("/" + smallestId + "/after/A.java")).findFirst().get();
+		String r1BeforeSourceCode = sourceCode(r1Before);
+		Assertions.assertTrue(r1BeforeSourceCode.contains("int a = 0;"));
+		String r1AfterSourceCode = sourceCode(r1After);
+		Assertions.assertTrue(r1AfterSourceCode.contains("int b = 0;"));
+
+		// r2: move source folder
+		// class A was isolated into its own class... the Utils class disappeared from A.java
+		String r2Before = Arrays.stream(allJavaFiles).filter(x -> x.contains("/" + (smallestId+1) + "/before/A.java")).findFirst().get();
+		String r2After = Arrays.stream(allJavaFiles).filter(x -> x.contains("/" + (smallestId+1) + "/after/A.java")).findFirst().get();
+		String r2BeforeSourceCode = sourceCode(r2Before);
+		Assertions.assertTrue(r2BeforeSourceCode.contains("class Utils"));
+		String r2AfterSourceCode = sourceCode(r2After);
+		Assertions.assertFalse(r2AfterSourceCode.contains("class Utils"));
+
+		// r3: move source folder
+		// connected to the previous one, but now it's the Utils class
+		String r3Before = Arrays.stream(allJavaFiles).filter(x -> x.contains("/" + (smallestId+2) + "/before/A.java")).findFirst().get();
+		String r3After = Arrays.stream(allJavaFiles).filter(x -> x.contains("/" + (smallestId+2) + "/after/Utils.java")).findFirst().get();
+		String r3BeforeSourceCode = sourceCode(r3Before);
+		Assertions.assertTrue(r3BeforeSourceCode.contains("class Utils"));
+		String r3AfterSourceCode = sourceCode(r3After);
+		Assertions.assertTrue(r3AfterSourceCode.contains("class Utils"));
+		Assertions.assertEquals(0, Arrays.stream(allJavaFiles).filter(x -> x.contains("/" + (smallestId+2) + "/before/Utils.java")).count());
+
+		// r4: Extract and Move Method
+		String r4Before = Arrays.stream(allJavaFiles).filter(x -> x.contains("/" + (smallestId+3) + "/before/A.java")).findFirst().get();
+		String r4After = Arrays.stream(allJavaFiles).filter(x -> x.contains("/" + (smallestId+3) + "/after/A.java")).findFirst().get();
+		String r4After2 = Arrays.stream(allJavaFiles).filter(x -> x.contains("/" + (smallestId+3) + "/after/Utils.java")).findFirst().get();
+		String r4BeforeSourceCode = sourceCode(r4Before);
+		Assertions.assertTrue(r4BeforeSourceCode.contains("int c = a + b"));
+		String r4AfterSourceCode = sourceCode(r4After);
+		Assertions.assertTrue(r4AfterSourceCode.contains("new Utils().m2copy();"));
+		String r4AfterSourceCode2 = sourceCode(r4After2);
+		Assertions.assertTrue(r4AfterSourceCode2.contains("public void m2copy"));
+		Assertions.assertEquals(0, Arrays.stream(allJavaFiles).filter(x -> x.contains("/" + (smallestId+3) + "/before/Utils.java")).count());
+
+		// r5: move and inline method
+		String r5Before = Arrays.stream(allJavaFiles).filter(x -> x.contains("/" + (smallestId+4) + "/before/A.java")).findFirst().get();
+		String r5Before2 = Arrays.stream(allJavaFiles).filter(x -> x.contains("/" + (smallestId+4) + "/before/Utils.java")).findFirst().get();
+		String r5After = Arrays.stream(allJavaFiles).filter(x -> x.contains("/" + (smallestId+4) + "/after/A.java")).findFirst().get();
+
+		String r5BeforeSourceCode = sourceCode(r5Before);
+		Assertions.assertTrue(r5BeforeSourceCode.contains("new Utils().m2copy();"));
+		String r5BeforeSourceCode2 = sourceCode(r5Before2);
+		Assertions.assertTrue(r5BeforeSourceCode2.contains("void m2copy()"));
+		String r5AfterSourceCode = sourceCode(r5After);
+		Assertions.assertTrue(r5AfterSourceCode.contains("int c = a + b"));
+
+	}
+
+	private String sourceCode(String file) {
+		try {
+			return new String(Files.readAllBytes(Paths.get(file)), StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	private Repository getRepository() throws IOException {

--- a/data-collection/src/test/java/refactoringml/UtilsTest.java
+++ b/data-collection/src/test/java/refactoringml/UtilsTest.java
@@ -59,6 +59,14 @@ public class UtilsTest {
 		}
 	}
 
+	@Test
+	public void onlyFileName() {
+		Assert.assertEquals("File.java", FilePathUtils.fileNameOnly("/some/dir/File.java"));
+		Assert.assertEquals("File.java", FilePathUtils.fileNameOnly("File.java"));
+		Assert.assertEquals("File.java", FilePathUtils.fileNameOnly("/File.java"));
+	}
+
+
 	private String generateRandomString(){
 		Random rnd = new Random();
 


### PR DESCRIPTION
This PR improves how we store the source code files. 

- [x] Use refactoringcommit id - See #137 
- [x] In some refactorings, we can't simply get the "old file" or the "new file" in Git. We might have to use the refactoringFilesBefore an refactoringFilesAfter from RMiner.
- [x] Write some tests
