### PR TITLE
Make the tool to work in cases where a Move + something else happens

### DIFF
--- a/data-collection/src/main/java/refactoringml/util/RefactoringUtils.java
+++ b/data-collection/src/main/java/refactoringml/util/RefactoringUtils.java
@@ -354,4 +354,12 @@ public class RefactoringUtils {
 		return Sets.newHashSet(it.next());
 	}
 
+	/**
+	 * Return on the refactorings that might change the name of the class.
+	 */
+	public static List<Refactoring> possibleClassRenames(List<Refactoring> refactorings) {
+		List<RefactoringType> renameTypes = Arrays.asList(RefactoringType.MOVE_RENAME_CLASS, RefactoringType.RENAME_CLASS, RefactoringType.MOVE_CLASS);
+		return refactorings.stream().filter(r -> renameTypes.contains(r.getRefactoringType())).collect(Collectors.toList());
+	}
+
 }

--- a/data-collection/src/test/java/integration/toyprojects/R7ToyProjectTest.java
+++ b/data-collection/src/test/java/integration/toyprojects/R7ToyProjectTest.java
@@ -30,9 +30,11 @@ public class R7ToyProjectTest extends IntegrationBaseTest {
 		return "https://github.com/refactoring-ai/toyrepo-r7.git";
 	}
 
-
 	@Test
 	void t1() {
-		getRefactoringCommits().forEach(x -> System.out.println(x.getRefactoringSummary()));
+		List<RefactoringCommit> refactorings = getRefactoringCommits();
+		Assertions.assertEquals(6, refactorings.size());
+
+		Assertions.assertTrue(refactorings.stream().anyMatch(x -> x.getRefactoring().equals("Extract Interface")));
 	}
 }

--- a/data-collection/src/test/java/integration/toyprojects/R7ToyProjectTest.java
+++ b/data-collection/src/test/java/integration/toyprojects/R7ToyProjectTest.java
@@ -1,0 +1,38 @@
+package integration.toyprojects;
+
+import integration.IntegrationBaseTest;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.Repository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import refactoringml.db.RefactoringCommit;
+import refactoringml.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static refactoringml.util.JGitUtils.extractProjectNameFromGitUrl;
+
+// tests related to PR #144: https://github.com/refactoring-ai/predicting-refactoring-ml/issues/144
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class R7ToyProjectTest extends IntegrationBaseTest {
+
+	@Override
+	protected String getRepo() {
+		return "https://github.com/refactoring-ai/toyrepo-r7.git";
+	}
+
+
+	@Test
+	void t1() {
+		getRefactoringCommits().forEach(x -> System.out.println(x.getRefactoringSummary()));
+	}
+}


### PR DESCRIPTION
Issue #144 was trickier than expected. When a Move happens (and as a consequence, the full class name changes/is renamed) together with another refactoring, RMiner returns, as the name of the class before the refactoring, the name of the class after the rename.

I could not find a rule. For example, if a Move happens together with a Extract Method, the Extract Method object has the class name of the class before the rename. However, if it's a Move + Extract Interface, the Extract Interface has the name of the class after the rename. 

(I opened an issue in RMiner to better understand this behaviour: https://github.com/tsantalis/RefactoringMiner/issues/90)

I had to do a good amount of workaround for that to work. First, I get a map of old -> new paths from Git. So that we can always use the old file name to retrieve the version of the class before the refactoring. Then, I get a map of renamed classes, so that we can also always use the old name of the class.

Toy projects tests are passing.