### PR TITLE
Ignore refactorings in anonymous classes

### DIFF
--- a/data-collection/src/main/java/refactoringml/App.java
+++ b/data-collection/src/main/java/refactoringml/App.java
@@ -212,7 +212,6 @@ public class App {
 
 				//check if refactoring miner detected a refactoring we study
 				if (thereIsRefactoringToProcess && !refactoringsToProcess.isEmpty()) {
-					db.persist(superCommitMetaData);
 					allRefactoringCommits = refactoringAnalyzer.collectCommitData(currentCommit, superCommitMetaData, refactoringsToProcess, entries);
 				} else if (thereIsRefactoringToProcess) {
 					// timeout happened, so count it as an exception

--- a/data-collection/src/main/java/refactoringml/RefactoringAnalyzer.java
+++ b/data-collection/src/main/java/refactoringml/RefactoringAnalyzer.java
@@ -103,7 +103,6 @@ public class RefactoringAnalyzer {
 							storeSourceCode(refactoringCommit.getId(), refactoring, commit);
 					} else {
 						log.debug("RefactoringCommit instance was not created for the class: " + refactoredClassName + " and the refactoring type: " + refactoring.getName()  + " on commit " + commit.getName());
-						// TODO: should we count the number of times we get here?
 					}
 				}
 			}

--- a/data-collection/src/main/java/refactoringml/RefactoringAnalyzer.java
+++ b/data-collection/src/main/java/refactoringml/RefactoringAnalyzer.java
@@ -75,7 +75,7 @@ public class RefactoringAnalyzer {
 					 * Thus, we skip this refactoring.
 					 */
 					if(fileDoesNotExist(refactoredClassFile)) {
-						log.info("Refactoring in a newly introduced file, which we skip: " + pair.getLeft() + ", commit = " + superCommitMetaData + ", refactoring = " + refactoringSummary);
+						log.debug("Refactoring in a newly introduced file, which we skip: " + pair.getLeft() + ", commit = " + superCommitMetaData + ", refactoring = " + refactoringSummary);
 						continue;
 					}
 
@@ -88,7 +88,7 @@ public class RefactoringAnalyzer {
 					 */
 					String refactoredClassNameFromRMiner = pair.getRight();
 					if(isAnonymousClass(refactoredClassNameFromRMiner)) {
-						log.info("Refactoring in an anonymous class, which we skip: " + refactoredClassNameFromRMiner + ", commit = " + superCommitMetaData + ", refactoring = " + refactoringSummary);
+						log.debug("Refactoring in an anonymous class, which we skip: " + refactoredClassNameFromRMiner + ", commit = " + superCommitMetaData + ", refactoring = " + refactoringSummary);
 						continue;
 					}
 					if(!persistedCommitMetaData){

--- a/data-collection/src/main/java/refactoringml/RefactoringAnalyzer.java
+++ b/data-collection/src/main/java/refactoringml/RefactoringAnalyzer.java
@@ -45,6 +45,7 @@ public class RefactoringAnalyzer {
 
 	public List<RefactoringCommit> collectCommitData(RevCommit commit, CommitMetaData superCommitMetaData, List<Refactoring> refactoringsToProcess, List<DiffEntry> entries) {
 		List<RefactoringCommit> allRefactorings = new ArrayList<>();
+		boolean persistedCommitMetaData = false;
 
 		try {
 			//get the map between new path -> old path
@@ -80,7 +81,7 @@ public class RefactoringAnalyzer {
 
 					/**
 					 * Now, we get the name of the class that was refactored. However, we skip refactorings in anonymous classes.
-					 * For us, it's pretty hard to get the code metrics for those (as CK 0.5.2 doesn't return
+					 * For us, it's pretty hard to get the code metrics for those (as CK 0.6.0 doesn't return
 					 * good names for anonymous classes).
 					 * (If the heuristic fail, it's not a problem, as later we won't be able to find code metrics for it; so we will never
 					 * store "bad data")
@@ -89,6 +90,10 @@ public class RefactoringAnalyzer {
 					if(isAnonymousClass(refactoredClassNameFromRMiner)) {
 						log.info("Refactoring in an anonymous class, which we skip: " + refactoredClassNameFromRMiner + ", commit = " + superCommitMetaData + ", refactoring = " + refactoringSummary);
 						continue;
+					}
+					if(!persistedCommitMetaData){
+						persistedCommitMetaData = true;
+						db.persist(superCommitMetaData);
 					}
 					ImmutablePair<String, String> refactoredClassName = new ImmutablePair<>(refactoredClassNameFromRMiner, classAliases.get(refactoredClassNameFromRMiner));
 

--- a/data-collection/src/main/java/refactoringml/util/RefactoringUtils.java
+++ b/data-collection/src/main/java/refactoringml/util/RefactoringUtils.java
@@ -385,4 +385,14 @@ public class RefactoringUtils {
 	public static List<Refactoring> possibleClassRenames(List<Refactoring> refactorings) {
 		return refactorings.stream().filter(RefactoringUtils::isClassRename).collect(Collectors.toList());
 	}
+
+	/**
+     * We detect anonymous classes by means of a simple heuristic: if the last part of a full class
+     * name starts with a lower case, odds are that it's an anonymous class.
+	 */
+	public static boolean isAnonymousClass(String fullName) {
+		String[] parts = fullName.split("\\.");
+		return Character.isLowerCase(parts[parts.length - 1].charAt(0));
+
+	}
 }

--- a/data-collection/src/main/resources/log4j2.xml
+++ b/data-collection/src/main/resources/log4j2.xml
@@ -58,6 +58,7 @@
     <Loggers>
         <Logger name="refactoringml" level="debug" additivity="false">
             <AppenderRef ref="RollingFile_INFO"/>
+            <AppenderRef ref="RollingFile_DEBUG"/>
             <AppenderRef ref="RollingFile_ERROR"/>
             <AppenderRef ref="Console_INFO"/>
         </Logger>

--- a/data-collection/src/test/java/integration/canaryprojects/TelegramServerIntegrationTest.java
+++ b/data-collection/src/test/java/integration/canaryprojects/TelegramServerIntegrationTest.java
@@ -25,7 +25,7 @@ public class TelegramServerIntegrationTest extends IntegrationBaseTest {
 	@Test
 	public void uniqueRefactorings(){
 		int uniqueRefactorings = getRefactoringCommits().stream().map(RefactoringCommit::getRefactoringSummary).distinct().collect(Collectors.toList()).size();
-		Assert.assertEquals(755, uniqueRefactorings);
+		Assert.assertEquals(753, uniqueRefactorings);
 	}
 
 	@Test

--- a/data-collection/src/test/java/integration/toyprojects/R8ToyProjectTest.java
+++ b/data-collection/src/test/java/integration/toyprojects/R8ToyProjectTest.java
@@ -24,5 +24,6 @@ public class R8ToyProjectTest extends IntegrationBaseTest {
 
 		Assertions.assertEquals("Rename Variable", refactorings.get(0).getRefactoring());
 
+		// TODO: we need some assertion here that makes sure the exception is not thrown. Ideas?
 	}
 }

--- a/data-collection/src/test/java/integration/toyprojects/R8ToyProjectTest.java
+++ b/data-collection/src/test/java/integration/toyprojects/R8ToyProjectTest.java
@@ -1,0 +1,28 @@
+package integration.toyprojects;
+
+import integration.IntegrationBaseTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import refactoringml.db.RefactoringCommit;
+
+import java.util.List;
+
+// tests related to PR #144: https://github.com/refactoring-ai/predicting-refactoring-ml/issues/144
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class R8ToyProjectTest extends IntegrationBaseTest {
+
+	@Override
+	protected String getRepo() {
+		return "https://github.com/refactoring-ai-testing/toyrepo-r8.git";
+	}
+
+	@Test
+	void t1() {
+		List<RefactoringCommit> refactorings = getRefactoringCommits();
+		Assertions.assertEquals(1, refactorings.size());
+
+		Assertions.assertEquals("Rename Variable", refactorings.get(0).getRefactoring());
+
+	}
+}

--- a/data-collection/src/test/java/refactoringml/RefactoringUtilsTest.java
+++ b/data-collection/src/test/java/refactoringml/RefactoringUtilsTest.java
@@ -19,4 +19,10 @@ public class RefactoringUtilsTest {
 		Assertions.assertFalse(RefactoringUtils.isAnonymousClass("a.b.c.d.ColumnQueryImpl"));
 		Assertions.assertFalse(RefactoringUtils.isAnonymousClass("a.b.c.d.ColumnQueryImpl.A"));
 	}
+
+	@Test
+	void defaultPackage() {
+		Assertions.assertFalse(RefactoringUtils.isAnonymousClass("ColumnQueryImpl"));
+		Assertions.assertTrue(RefactoringUtils.isAnonymousClass("ColumnQueryImpl.execute.result.doExecute"));
+	}
 }

--- a/data-collection/src/test/java/refactoringml/RefactoringUtilsTest.java
+++ b/data-collection/src/test/java/refactoringml/RefactoringUtilsTest.java
@@ -1,0 +1,22 @@
+package refactoringml;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import refactoringml.util.RefactoringUtils;
+
+public class RefactoringUtilsTest {
+
+	@Test
+	void identifyAnonymousClassesOrMethods() {
+		Assertions.assertTrue(RefactoringUtils.isAnonymousClass("a.ColumnQueryImpl.execute.result.doExecute"));
+		Assertions.assertTrue(RefactoringUtils.isAnonymousClass("a.b.c.d.ColumnQueryImpl.execute.result.doExecute"));
+		Assertions.assertTrue(RefactoringUtils.isAnonymousClass("a.b.c.d.ColumnQueryImpl.A.execute.result.doExecute"));
+	}
+
+	@Test
+	void identifyRegularClasses() {
+		Assertions.assertFalse(RefactoringUtils.isAnonymousClass("a.ColumnQueryImpl"));
+		Assertions.assertFalse(RefactoringUtils.isAnonymousClass("a.b.c.d.ColumnQueryImpl"));
+		Assertions.assertFalse(RefactoringUtils.isAnonymousClass("a.b.c.d.ColumnQueryImpl.A"));
+	}
+}


### PR DESCRIPTION
This PR aims to tackle issue #142. All the non-linked refactorings between RMiner and CK are related to anonymous classes.

While CK doesn't implement better names in anonymous classes, so that we could do the link, it's better to ignore it. The number of these refactorings is not significant anyways.