### PR TITLE
Fix multiple issues in cache warm-up and querybuilder

### DIFF
--- a/machine-learning/configs.py
+++ b/machine-learning/configs.py
@@ -3,6 +3,8 @@
 # --------------------------------
 # is it a test run?
 # test runs reduce the dataset to 100 instances only
+from enum import IntEnum
+
 TEST = False
 
 # --------------------------------
@@ -87,11 +89,21 @@ DEEP_MODELS = ['neural-network']
 
 # Empty dataset means 'all datasets'
 # options = ['', 'apache', 'github', 'fdroid']
-DATASETS = ['', 'apache', 'github', 'fdroid']
+DATASETS = ['']
+
 
 # --------------------------------
 # Refactorings
 # --------------------------------
+
+#refactoring levels
+class Level(IntEnum):
+    NONE = 0
+    Class = 1
+    Method = 2
+    Variable = 3
+    Field = 4
+    Other = 5
 
 # Refactorings to study
 CLASS_LEVEL_REFACTORINGS = ["Extract Class",
@@ -141,6 +153,14 @@ FIELD_LEVEL_REFACTORINGS = ["Move Attribute",
 
 OTHER_LEVEL_REFACTORINGS = ["Move Source Folder",
                             "Change Package"]
+
+
+levelMap = {Level.NONE: [],
+            Level.Class: CLASS_LEVEL_REFACTORINGS,
+            Level.Method: METHOD_LEVEL_REFACTORINGS,
+            Level.Field: FIELD_LEVEL_REFACTORINGS,
+            Level.Variable: VARIABLE_LEVEL_REFACTORINGS,
+            Level.Other: OTHER_LEVEL_REFACTORINGS}
 # --------------------------------
 # DO NOT CHANGE FROM HERE ON
 # --------------------------------

--- a/machine-learning/db/QueryBuilder.py
+++ b/machine-learning/db/QueryBuilder.py
@@ -163,6 +163,8 @@ def get_metrics_level(level: int):
     elif level == 4:
         return [(classMetrics, classMetricsFields), (fieldMetrics, fieldMetricsFields),
                 (processMetrics, processMetricsFields)]
+    elif level == 5:
+        return [(classMetrics, classMetricsFields), (processMetrics, processMetricsFields)]
 
 
 # Create a sql select statement for the given instance and requested fields
@@ -190,16 +192,19 @@ def get_instance_fields(instance_name: str, fields, conditions: str = "", datase
     join_conditions = join_conditions[:-5]
 
     sql: str = "SELECT " + required_fields + " FROM " + required_tables + " WHERE " + join_conditions
-    if conditions != "":
+    if len(conditions) > 2:
         if not sql.endswith(' WHERE '):
             sql += " AND "
         sql += conditions
-    if dataset != "":
+    if len(dataset) > 0:
         if not sql.endswith(' WHERE '):
             sql += " AND "
         sql += project_filter(instance_name, dataset)
-
-    return sql + " " + order
+    if sql.endswith(' WHERE '):
+        sql = sql[:-7]
+    if len(order) > 8:
+        sql += " " + order
+    return sql
 # endregion
 
 
@@ -255,6 +260,6 @@ def get_all_level_stable(level: int, dataset: str = "") -> str:
 # get all unique refactoring types as a list
 # Optional dataset: filter to this specific project
 def get_refactoring_types(dataset: str = "") -> str:
-    return ""
-    # TODO: implement
+    return "SELECT DISTINCT refactoring FROM " \
+           "(" + get_instance_fields(refactoringCommits, [(refactoringCommits, ["refactoring"])], "", dataset) + ") t"
 # endregion

--- a/machine-learning/db/test_QueryBuilder.py
+++ b/machine-learning/db/test_QueryBuilder.py
@@ -1,7 +1,7 @@
 import unittest
 from db.QueryBuilder import project_filter, join_tables, get_metrics_level, get_instance_fields, \
     get_refactoring_levels, get_level_refactorings_count, get_all_level_refactorings, get_all_level_stable, \
-    get_level_refactorings
+    get_level_refactorings, get_refactoring_types
 
 
 class QueryBuilderUnitTest(unittest.TestCase):
@@ -30,24 +30,24 @@ class QueryBuilderUnitTest(unittest.TestCase):
 
 
     def test_get_instance_fields(self):
-        sqlExpected: str = "SELECT refactoringcommit.className, commitmetadata.commitId FROM refactoringcommit, commitmetadata WHERE refactoringcommit.commitmetadata_id = commitmetadata.id "
+        sqlExpected: str = "SELECT refactoringcommit.className, commitmetadata.commitId FROM refactoringcommit, commitmetadata WHERE refactoringcommit.commitmetadata_id = commitmetadata.id"
         sqlBuilt: str = get_instance_fields("refactoringcommit",
                                             [("refactoringcommit", ["className"]), ("commitmetadata", ["commitId"])])
         self.assertEqual(sqlExpected, sqlBuilt)
 
-        sqlExpected += "AND commitmetadata.parentCommitId != null "
+        sqlExpected += " AND commitmetadata.parentCommitId != null"
         sqlBuilt: str = get_instance_fields("refactoringcommit",
                                             [("refactoringcommit", ["className"]), ("commitmetadata", ["commitId"])],
                                             "commitmetadata.parentCommitId != null")
 
-        sqlExpected += "AND refactoringcommit.project_id in (select id from project where datasetName = \"integration-test\") "
+        sqlExpected += " AND refactoringcommit.project_id in (select id from project where datasetName = \"integration-test\")"
         sqlBuilt: str = get_instance_fields("refactoringcommit",
                                             [("refactoringcommit", ["className"]), ("commitmetadata", ["commitId"])],
                                             "commitmetadata.parentCommitId != null",
                                             "integration-test")
         self.assertEqual(sqlExpected, sqlBuilt)
 
-        sqlExpected += "order by commitmetadata.commitDate"
+        sqlExpected += " order by commitmetadata.commitDate"
         sqlBuilt: str = get_instance_fields("refactoringcommit",
                                             [("refactoringcommit", ["className"]), ("commitmetadata", ["commitId"])],
                                             "commitmetadata.parentCommitId != null",
@@ -83,10 +83,15 @@ class QueryBuilderUnitTest(unittest.TestCase):
 
 
     def test_get_level_refactorings_count(self):
-        sqlExpected: str = "SELECT refactoring, count(*) FROM (SELECT refactoringcommit.refactoring FROM refactoringcommit WHERE refactoringcommit.level = 2 AND refactoringcommit.project_id in (select id from project where datasetName = \"integration-test\") ) t group by refactoring order by count(*) desc"
+        sqlExpected: str = "SELECT refactoring, count(*) FROM (SELECT refactoringcommit.refactoring FROM refactoringcommit WHERE refactoringcommit.level = 2 AND refactoringcommit.project_id in (select id from project where datasetName = \"integration-test\")) t group by refactoring order by count(*) desc"
         sqlBuilt: str = get_level_refactorings_count(2, "integration-test")
         self.assertEqual(sqlExpected, sqlBuilt)
 
+
+    def test_get_refactoring_types(self):
+        sqlExpected: str = "SELECT DISTINCT refactoring FROM (SELECT refactoringcommit.refactoring FROM refactoringcommit WHERE refactoringcommit.project_id in (select id from project where datasetName = \"integration-test\")) t"
+        sqlBuilt: str = get_refactoring_types("integration-test")
+        self.assertEqual(sqlExpected, sqlBuilt)
 
 if __name__ == '__main__':
     unittest.main()

--- a/machine-learning/refactoring.py
+++ b/machine-learning/refactoring.py
@@ -1,92 +1,37 @@
-from configs import CLASS_LEVEL_REFACTORINGS, VARIABLE_LEVEL_REFACTORINGS, METHOD_LEVEL_REFACTORINGS, \
-    FIELD_LEVEL_REFACTORINGS
+import itertools
+
+from configs import Level, levelMap
 from db.QueryBuilder import get_level_refactorings, get_all_level_stable
 from db.DBConnector import execute_query
+from utils.log import log
 
 
-class LowLevelRefactoring():
+class LowLevelRefactoring:
     _name = ""
+    _level = Level.NONE
 
-    def __init__(self, name):
+    def __init__(self, name, level):
         self._name = name
+        self._level = level
 
     def get_refactored_instances(self, dataset):
-        pass
+        return execute_query(get_level_refactorings(int(self._level), self._name, dataset))
 
     def get_non_refactored_instances(self, dataset):
-        pass
+        return execute_query(get_all_level_stable(int(self._level), dataset))
 
-    def refactoring_level(self):
-        pass
+    def refactoring_level(self) -> str:
+        return str(self._level)
 
-    def name(self):
+    def name(self) -> str:
         return self._name
 
 
-class MethodLevelRefactoring(LowLevelRefactoring):
-
-    def __init__(self, name):
-        super().__init__(name)
-
-    def get_refactored_instances(self, dataset):
-        return execute_query(get_level_refactorings(2, self._name, dataset))
-
-    def get_non_refactored_instances(self, dataset):
-        return execute_query(get_all_level_stable(2, dataset))
-
-    def refactoring_level(self):
-        return "method"
-
-
-class ClassLevelRefactoring(LowLevelRefactoring):
-
-    def __init__(self, name):
-        super().__init__(name)
-
-    def get_refactored_instances(self, dataset):
-        return execute_query(get_level_refactorings(1, self._name, dataset))
-
-    def get_non_refactored_instances(self, dataset):
-        return execute_query(get_all_level_stable(1, dataset))
-
-    def refactoring_level(self):
-        return "class"
-
-
-class VariableLevelRefactoring(LowLevelRefactoring):
-
-    def __init__(self, name):
-        super().__init__(name)
-
-    def get_refactored_instances(self, dataset):
-        return execute_query(get_level_refactorings(3, self._name, dataset))
-
-    def get_non_refactored_instances(self, dataset):
-        return execute_query(get_all_level_stable(3, dataset))
-
-    def refactoring_level(self):
-        return "variable"
-
-
-class FieldLevelRefactoring(LowLevelRefactoring):
-
-    def __init__(self, name):
-        super().__init__(name)
-
-    def get_refactored_instances(self, dataset):
-        return execute_query(get_level_refactorings(4, self._name, dataset))
-
-    def get_non_refactored_instances(self, dataset):
-        return execute_query(get_all_level_stable(4, dataset))
-
-    def refactoring_level(self):
-        return "field"
-
-
 def build_refactorings():
-    class_level_refactorings = list(map(lambda r: ClassLevelRefactoring(r), CLASS_LEVEL_REFACTORINGS))
-    method_level_refactorings = list(map(lambda r: MethodLevelRefactoring(r), METHOD_LEVEL_REFACTORINGS))
-    variable_level_refactorings = list(map(lambda r: VariableLevelRefactoring(r), VARIABLE_LEVEL_REFACTORINGS))
-    field_level_refactorings = list(map(lambda r: FieldLevelRefactoring(r), FIELD_LEVEL_REFACTORINGS))
+    all_refactorings = []
+    for level in Level:
+        for refactoring in levelMap[level]:
+            all_refactorings += [LowLevelRefactoring(refactoring, level)]
+    log("Trying to fetch " + str(len(all_refactorings)) + " refactoring types.")
 
-    return class_level_refactorings + method_level_refactorings + variable_level_refactorings + field_level_refactorings
+    return all_refactorings

--- a/machine-learning/utils/log.py
+++ b/machine-learning/utils/log.py
@@ -1,4 +1,5 @@
 import random
+from pathlib import Path
 
 from configs import TEST, USE_CACHE, BALANCE_DATASET, BALANCE_DATASET_STRATEGY, SCALE_DATASET, FEATURE_REDUCTION, \
     N_CV_FEATURE_REDUCTION, SEARCH, N_CV_SEARCH, N_ITER_RANDOM_SEARCH, N_CV, DATASETS, MODELS, DEEP_MODELS, \
@@ -31,6 +32,7 @@ def print_config():
 
 def log_init():
     global _f
+    Path("results/").mkdir(parents=True, exist_ok=True)
     _f = open("results/{}-result.txt".format(random.randint(1, 999999)), "w+")
 
     log(r"  __  __ _      _ _    ___      __         _           _           ")

--- a/machine-learning/warm_cache.py
+++ b/machine-learning/warm_cache.py
@@ -1,9 +1,12 @@
-from enum import Enum
+from enum import IntEnum
+
+from configs import DATASETS
 from db.QueryBuilder import get_all_level_stable, get_level_refactorings_count, get_level_refactorings, get_refactoring_types
 from db.DBConnector import execute_query
+from utils.log import log_init, log_close
 
 
-class Level(Enum):
+class Level(IntEnum):
     Class = 1
     Method = 2
     Variable = 3
@@ -11,11 +14,10 @@ class Level(Enum):
     Other = 5
 
 
-datasets = ['', 'apache', 'github', 'fdroid']
+datasets = DATASETS
 
-
-print('begin cache warmup')
-
+log_init()
+print('begin cache warm-up')
 
 for dataset in datasets:
     print("dataset: " + dataset)
@@ -34,10 +36,10 @@ for dataset in datasets:
 
     for level in Level:
         print("-- " + str(level) + " level refactoring count")
-        refactorings =  execute_query(get_level_refactorings_count(int(level), dataset))
+        refactorings = execute_query(get_level_refactorings_count(int(level), dataset))
         for refactoring_name in refactorings["refactoring"].values:
             print("---- " + refactoring_name)
             execute_query(get_level_refactorings(int(level), refactoring_name, dataset))
 
-
-print('end cache warmup')
+print('end cache warm-up')
+log_close()

--- a/machine-learning/warm_cache.py
+++ b/machine-learning/warm_cache.py
@@ -1,18 +1,7 @@
-from enum import IntEnum
-
 from configs import DATASETS
 from db.QueryBuilder import get_all_level_stable, get_level_refactorings_count, get_level_refactorings, get_refactoring_types
 from db.DBConnector import execute_query
 from utils.log import log_init, log_close
-
-
-class Level(IntEnum):
-    Class = 1
-    Method = 2
-    Variable = 3
-    Field = 4
-    Other = 5
-
 
 datasets = DATASETS
 


### PR DESCRIPTION
### Fix
 * Create results dir, if non exists
 * Create logger for cache warmup if non exists
 * Implement get_refactoring_types() in Querybuilder
 * Fix empty dataset handling in Querybuilder
 * Minor bug fixes in Querybuilder
 * Fix enum use in warm_cache, by changing it to IntEnum

### Refactoring:
* Refactored refactoring levels in refactoring.py 

### Other
 * Add test for get_refactoring_types()